### PR TITLE
fix: trigger S3_Uploads\init on init instead of plugins_loaded

### DIFF
--- a/s3-uploads.php
+++ b/s3-uploads.php
@@ -10,7 +10,7 @@ Author URI: https://hmn.md
 
 require_once __DIR__ . '/inc/namespace.php';
 
-add_action( 'plugins_loaded', 'S3_Uploads\\init' );
+add_action( 'init', 'S3_Uploads\\init' );
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	WP_CLI::add_command( 's3-uploads', 'S3_Uploads\\WP_CLI_Command' );


### PR DESCRIPTION
By triggering the S3_Uploads\init call on `plugins_loaded` it makes it impossible to add a filter on s3_uploads_s3_client_params in a theme as this event is always called before setting up the theme.

Switching to `init` should not have any adverse effect and permit theme to override s3 params.